### PR TITLE
Amélioration des formulaires de création d'événement/GA + permettre de nouveau la modification du contact_name sur les GA

### DIFF
--- a/src/front/forms/groups.py
+++ b/src/front/forms/groups.py
@@ -148,7 +148,7 @@ class SupportGroupForm(LocationFormMixin, ContactFormMixin, forms.ModelForm):
         model = SupportGroup
         fields = (
             'name', 'type', 'subtypes',
-            'contact_email', 'contact_phone', 'contact_hide_phone',
+            'contact_name', 'contact_email', 'contact_phone', 'contact_hide_phone',
             'location_name', 'location_address1', 'location_address2', 'location_city', 'location_zip',
             'location_country',
             'description'

--- a/src/javascript_components/creationForms/createEventForm.js
+++ b/src/javascript_components/creationForms/createEventForm.js
@@ -43,7 +43,6 @@ class CreateEventForm extends React.Component {
   async componentDidMount() {
     let subtypes = (await axios.get(apiEndpoint + '/events_subtypes/')).data;
     this.setState({subtypes});
-
   }
 
   setFields(fields) {
@@ -58,11 +57,11 @@ class CreateEventForm extends React.Component {
     let steps = [
       {
         name: 'Quel type ?',
-        component: <EventTypeStep setFields={this.setFields} subtypes={this.state.subtypes} step={0} />
+        component: <EventTypeStep setFields={this.setFields} subtypes={this.state.subtypes} fields={this.state.fields} step={0} />
       },
-      {name: 'Qui ?', component: <ContactStep setFields={this.setFields} step={1} />},
-      {name: 'Quand ?', component: <ScheduleStep setFields={this.setFields} step={2} />},
-      {name: 'Où ?', component: <LocationStep setFields={this.setFields} step={3} />},
+      {name: 'Qui ?', component: <ContactStep setFields={this.setFields} fields={this.state.fields} step={1} />},
+      {name: 'Quand ?', component: <ScheduleStep setFields={this.setFields} fields={this.state.fields} step={2} />},
+      {name: 'Où ?', component: <LocationStep setFields={this.setFields} fields={this.state.fields} step={3} />},
       {name: 'Validation et nom', component: <ValidateStep fields={this.state.fields} step={4} />},
     ];
 
@@ -78,24 +77,27 @@ class CreateEventForm extends React.Component {
 class EventTypeStep extends FormStep {
   constructor(props) {
     super(props);
+    this.state.fields.subtype = props.fields.subtype;
+    this.setFields = this.setFields.bind(this);
+    this.confirm = this.confirm.bind(this);
     this.allSubtypes = props.subtypes;
     this.rankedSubtypes = props.subtypes.reduce((acc, s) => {
       (acc[s.type] = acc[s.type] || []).push(s);
       return acc;
     }, {});
-    this.confirm = this.confirm.bind(this);
-    this.setSubtype = this.setSubtype.bind(this);
-
-    this.state = {subtype: null};
   }
 
   setSubtype(subtype) {
-    this.setState({subtype});
+    this.setState({
+      fields: Object.assign(this.state.fields, {
+        subtype: subtype,
+      })
+    });
   }
 
   confirm(e) {
     e.preventDefault();
-    this.props.setFields({subtype: this.state.subtype});
+    this.setFields({subtype: this.state.fields.subtype});
     this.jumpToStep(1);
   }
 
@@ -105,7 +107,7 @@ class EventTypeStep extends FormStep {
         <div className="col-sm-6">
           <h2>Quel type d'événement voulez-vous créer ?</h2>
           <p>
-            Chaque insoumis.e peut créer un événement sur la plateforme dès lors
+            Chaque insoumis·e peut créer un événement sur la plateforme dès lors
             qu’il respecte le cadre et la démarche de la France insoumise dans un esprit
             d’ouverture, de bienveillance et de volonté de se projeter dans l’action.
           </p>
@@ -124,12 +126,12 @@ class EventTypeStep extends FormStep {
                   <ul className="nav nav-pills">
                     {
                       this.rankedSubtypes[type.id].map(subtype => (
-                        <li className={subtype === this.state.subtype ? 'active' : ''} key={subtype.description}>
+                        <li className={subtype === this.state.fields.subtype ? 'active' : ''} key={subtype.description}>
                           <a href="#" onClick={(e) => {
                             e.preventDefault();
-                            this.setSubtype(subtype)
+                            this.setSubtype(subtype);
                           }}>
-                            <i className={'fa ' + (subtype === this.state.subtype ? 'fa-check-circle' : 'fa-circle-o')}/>
+                            <i className={'fa ' + (subtype === this.state.fields.subtype ? 'fa-check-circle' : 'fa-circle-o')}/>
                             &nbsp;
                             {subtype.description}
                           </a>
@@ -140,7 +142,7 @@ class EventTypeStep extends FormStep {
                 </div>
               ))
             }
-            <button className="btn btn-primary" type="submit" disabled={!this.state.subtype}>
+            <button className="btn btn-primary" type="submit" disabled={!this.state.fields.subtype}>
               Suivant&nbsp;&rarr;
             </button>
           </form>
@@ -164,6 +166,7 @@ class ValidateStep extends FormStep {
     let data = qs.stringify({
       name: this.eventName.value,
       contact_email: this.state.fields.email,
+      contact_name: this.state.fields.name || null,
       contact_phone: this.state.fields.phone,
       contact_hide_phone: this.state.fields.hidePhone,
       start_time: this.state.fields.startTime.format('YYYY-MM-DD HH:mm:SS'),
@@ -175,7 +178,7 @@ class ValidateStep extends FormStep {
       location_city: this.state.fields.locationCity,
       location_country: this.state.fields.locationCountryCode,
       subtype: this.state.fields.subtype.label,
-      calendar: "1",
+      calendar: '1',
     });
 
     try {
@@ -199,6 +202,11 @@ class ValidateStep extends FormStep {
               <strong>Numéro de
                 téléphone&nbsp;:</strong> {this.state.fields.phone} ({this.state.fields.hidePhone === 'on' ? 'caché' : 'public'})
             </li>
+            {this.state.fields.name &&
+              <li>
+                <strong>Nom du contact pour l'événement&nbsp;:</strong> {this.state.fields.name}
+              </li>
+            }
             <li>
               <strong>Adresse email de contact pour l'événement&nbsp;:</strong> {this.state.fields.email}
             </li>
@@ -220,13 +228,13 @@ class ValidateStep extends FormStep {
           <form onSubmit={this.post}>
             <div className="form-group">
               <input className="form-control" ref={i => this.eventName = i} type="text" placeholder="Nom de l'événement"
-                     required/>
+                required/>
             </div>
             <button className="btn btn-primary" type="submit" disabled={this.state.processing}>Créer mon événement</button>
           </form>
           {this.state.error && (
             <div className="alert alert-warning">
-              Un erreur s'est produite. Merci de réessayer plus tard.
+              Une erreur s'est produite. Merci de réessayer plus tard.
             </div>
           )}
         </div>

--- a/src/javascript_components/creationForms/createGroupForm.js
+++ b/src/javascript_components/creationForms/createGroupForm.js
@@ -44,9 +44,9 @@ class CreateGroupForm extends React.Component {
     }
 
     let steps = [
-      {name: 'Un groupe pour quoi ?', component: <GroupTypeStep setFields={this.setFields} subtypes={this.state.subtypes} step={0} />},
-      {name: 'Informations de contact', component: <ContactStep setFields={this.setFields} step={1} />},
-      {name: 'Localisation', component: <LocationStep setFields={this.setFields} step={2} />},
+      {name: 'Un groupe pour quoi ?', component: <GroupTypeStep setFields={this.setFields} fields={this.state.fields} subtypes={this.state.subtypes} step={0} />},
+      {name: 'Informations de contact', component: <ContactStep setFields={this.setFields} fields={this.state.fields} step={1} />},
+      {name: 'Localisation', component: <LocationStep setFields={this.setFields} fields={this.state.fields} step={2} />},
       {name: 'Validation et nom', component: <ValidateStep fields={this.state.fields} step={3} />},
     ];
 
@@ -170,6 +170,7 @@ class ValidateStep extends FormStep {
 
     let data = qs.stringify({
       name: this.groupName.value,
+      contact_name: this.state.fields.name || null,
       contact_email: this.state.fields.email,
       contact_phone: this.state.fields.phone,
       contact_hide_phone: this.state.fields.hidePhone,
@@ -203,6 +204,11 @@ class ValidateStep extends FormStep {
             <li>
               <strong>Numéro de téléphone&nbsp;:</strong> {this.state.fields.phone} ({this.state.fields.hidePhone === 'on' ? 'caché' : 'public'})
             </li>
+            {this.state.fields.name &&
+              <li>
+                <strong>Nom du contact&nbsp;:</strong> {this.state.fields.name}
+              </li>
+            }
             <li>
               <strong>Adresse email du groupe&nbsp;:</strong> {this.state.fields.email}
             </li>
@@ -226,7 +232,7 @@ class ValidateStep extends FormStep {
           </form>
           { this.state.error && (
             <div className="alert alert-warning">
-              Un erreur s'est produite. Merci de réessayer plus tard.
+              Une erreur s'est produite. Merci de réessayer plus tard.
             </div>
           ) }
         </div>

--- a/src/javascript_components/creationForms/steps/ContactStep.js
+++ b/src/javascript_components/creationForms/steps/ContactStep.js
@@ -11,13 +11,20 @@ import FormStep from './FormStep';
 class ContactStep extends FormStep {
   constructor(props) {
     super(props);
+    this.state.fields = {
+      name: props.fields.name || '',
+      email: props.fields.email || '',
+      phone: props.fields.phone || '',
+      hidePhone: props.fields.hidePhone || false,
+    };
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
   }
 
   handleSubmit(event) {
     event.preventDefault();
 
-    let phone = this.phone.value;
+    let phone = this.state.fields.phone;
     let phoneValid = false;
     try {
       let phoneNumber = phoneUtil.parse(phone, 'FR');
@@ -31,7 +38,12 @@ class ContactStep extends FormStep {
       return this.setState({errors: {phone: 'Vous devez entrer un numéro de téléphone valide.'}});
     }
 
-    this.setFields({phone, email: this.email.value, hidePhone: this.hidePhone.value});
+    this.setFields({
+      name: this.state.fields.name,
+      email: this.state.fields.email,
+      phone,
+      hidePhone: this.state.fields.hidePhone
+    });
     this.jumpToStep(this.props.step + 1);
   }
 
@@ -42,8 +54,9 @@ class ContactStep extends FormStep {
           <h4>Informations de contact</h4>
           <p>
             Ces informations sont les informations de contact. Vous devez indiquer une adresse email et un
-            numéro de téléphone. Ce ne sont pas forcément vos informations de contact personnelles&nbsp;: en
-            particulier, l'adresse email peut créée pour l'occasion et être relevée par plusieurs personnes.
+            numéro de téléphone. Vous pouvez également préciser le nom d'un·e contact. Ce ne sont pas forcément
+            vos informations de contact personnelles&nbsp;: en particulier, l'adresse email peut être créée pour
+            l'occasion et être relevée par plusieurs personnes.
           </p>
           <p>
             Vous pouvez ne pas rendre le numéro de téléphone public (surtout si c'est votre numéro personnel).
@@ -52,28 +65,36 @@ class ContactStep extends FormStep {
           </p>
           {
             this.props.step > 0 &&
-            <a className="btn btn-default"
-               onClick={() => this.jumpToStep(this.props.step - 1)}>&larr;&nbsp;Précédent</a>
+            <a className="btn btn-default" onClick={() => this.jumpToStep(this.props.step - 1)}>&larr;&nbsp;Précédent</a>
           }
         </div>
         <div className="col-md-6">
           <form onSubmit={this.handleSubmit}>
             <div className="form-group">
+              <label>Nom du contact (facultatif)</label>
+              <input className="form-control" name="name" type="text" value={this.state.fields.name} onChange={this.handleInputChange}/>
+            </div>
+            <div className="form-group">
               <label>Adresse email de contact</label>
-              <input className="form-control" ref={i => this.email = i} type="email"/>
+              <input className="form-control" name="email" type="email" value={this.state.fields.email} onChange={this.handleInputChange} required/>
             </div>
             <label>Numéro de téléphone du contact</label>
             <div className="row">
               <div className="col-md-6">
                 <div className={'form-group' + (this.state.errors.phone ? ' has-error' : '')}>
-                  <Cleave options={{phone: true, phoneRegionCode: 'FR'}} htmlRef={(i => this.phone = i)} className="form-control"/>
+                  <Cleave
+                    options={{phone: true, phoneRegionCode: 'FR'}}
+                    className="form-control"
+                    name="phone"
+                    value={this.state.fields.phone}
+                    onChange={this.handleInputChange} />
                   {this.state.errors.phone ? (<span className="help-block">{this.state.errors.phone}</span>) : ''}
                 </div>
               </div>
               <div className="col-md-6">
                 <div className="checkbox">
                   <label>
-                    <input ref={i => this.hidePhone = i} type="checkbox"/> Ne pas rendre public
+                    <input type="checkbox" name="hidePhone" checked={this.state.fields.hidePhone} onChange={this.handleInputChange}/> Ne pas rendre public
                   </label>
                 </div>
               </div>

--- a/src/javascript_components/creationForms/steps/FormStep.js
+++ b/src/javascript_components/creationForms/steps/FormStep.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class FormStep extends React.Component {
@@ -6,11 +6,21 @@ export default class FormStep extends React.Component {
     super(props);
     this.setFields = props.setFields;
     this.jumpToStep = props.jumpToStep;
-    this.state = {errors: {}};
+    this.state = {errors: {}, fields: {}};
+  }
+
+  handleInputChange(event) {
+    const target = event.target;
+    const value = target.type === 'checkbox' ? target.checked : target.value;
+    const name = target.name;
+    this.setState({
+      fields: Object.assign(this.state.fields, {[name]: value}),
+    });
   }
 }
 
 FormStep.propTypes = {
   setFields: PropTypes.func,
-  jumpToStep: PropTypes.func
+  jumpToStep: PropTypes.func,
+  fields: PropTypes.object,
 };

--- a/src/javascript_components/creationForms/steps/LocationStep.js
+++ b/src/javascript_components/creationForms/steps/LocationStep.js
@@ -6,19 +6,28 @@ import FormStep from './FormStep';
 export default class LocationStep extends FormStep {
   constructor(props) {
     super(props);
+    this.state.fields = {
+      locationName: props.fields.locationName || '',
+      locationAddress1: props.fields.locationAddress1 || '',
+      locationAddress2: props.fields.locationAddress2 || '',
+      locationZip: props.fields.locationZip || '',
+      locationCity: props.fields.locationCity || '',
+      locationCountryCode: props.fields.locationCountryCode || 'FR',
+    };
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
   }
 
   handleSubmit(event) {
     event.preventDefault();
 
     this.setFields({
-      locationName: this.locationName.value,
-      locationAddress1: this.locationAddress1.value,
-      locationAddress2: this.locationAddress2.value,
-      locationZip: this.locationZip.value,
-      locationCity: this.locationCity.value,
-      locationCountryCode: this.locationCountryCode.value,
+      locationName: this.state.fields.locationName,
+      locationAddress1: this.state.fields.locationAddress1,
+      locationAddress2: this.state.fields.locationAddress2,
+      locationZip: this.state.fields.locationZip,
+      locationCity: this.state.fields.locationCity,
+      locationCountryCode: this.state.fields.locationCountryCode,
     });
     this.jumpToStep(this.props.step + 1);
   }
@@ -38,40 +47,74 @@ export default class LocationStep extends FormStep {
           {
             this.props.step > 0 &&
             <a className="btn btn-default"
-               onClick={() => this.jumpToStep(this.props.step - 1)}>&larr;&nbsp;Précédent</a>
+              onClick={() => this.jumpToStep(this.props.step - 1)}>&larr;&nbsp;Précédent</a>
           }
         </div>
         <div className="col-md-6">
           <form onSubmit={this.handleSubmit}>
             <div className="form-group">
               <label>Nom du lieu</label>
-              <input ref={i => this.locationName = i} placeholder="Exemple: café de la gare, rue des postes..."
-                     className="form-control" type="text" required/>
+              <input
+                name="locationName"
+                onChange={this.handleInputChange}
+                value={this.state.fields.locationName}
+                placeholder="Exemple : café de la gare, rue des postes..."
+                className="form-control"
+                type="text"
+                required/>
             </div>
             <div className="form-group">
               <label className="control-label">Adresse</label>
-              <input ref={i => this.locationAddress1 = i} placeholder="1ère ligne" className="form-control" type="text"
-                     required/>
-              <input ref={i => this.locationAddress2 = i} placeholder="2ème ligne" className="form-control"
-                     type="text"/>
+              <input
+                name="locationAddress1"
+                onChange={this.handleInputChange}
+                value={this.state.fields.locationAddress1}
+                placeholder="1ère ligne"
+                className="form-control"
+                type="text"
+                required/>
+              <input
+                name="locationAddress2"
+                onChange={this.handleInputChange}
+                value={this.state.fields.locationAddress2}
+                placeholder="2ème ligne"
+                className="form-control"
+                type="text"/>
             </div>
             <div className="row">
               <div className="col-md-4">
                 <div className="form-group">
                   <label className="control-label">Code postal</label>
-                  <input ref={i => this.locationZip = i} className="form-control" type="text" required/>
+                  <input
+                    name="locationZip"
+                    onChange={this.handleInputChange}
+                    value={this.state.fields.locationZip}
+                    className="form-control"
+                    type="text"
+                    required/>
                 </div>
               </div>
               <div className="col-md-8">
                 <div className="form-group">
                   <label className="control-label">Ville</label>
-                  <input ref={i => this.locationCity = i} className="form-control" type="text" required/>
+                  <input
+                    name="locationCity"
+                    onChange={this.handleInputChange}
+                    value={this.state.fields.locationCity}
+                    className="form-control"
+                    type="text"
+                    required/>
                 </div>
               </div>
             </div>
             <div className="form-group">
               <label className="control-label">Pays</label>
-              <select ref={i => this.locationCountryCode = i} className="form-control" required defaultValue='FR'>
+              <select
+                name="locationCountryCode"
+                onChange={this.handleInputChange}
+                value={this.state.fields.locationCountryCode}
+                className="form-control"
+                required>
                 {countries.array().map(country => (
                   <option value={country.code} key={country.code}>{country.label}</option>))}
               </select>
@@ -82,4 +125,4 @@ export default class LocationStep extends FormStep {
       </div>
     );
   }
-};
+}

--- a/src/javascript_components/creationForms/steps/ScheduleStep.js
+++ b/src/javascript_components/creationForms/steps/ScheduleStep.js
@@ -11,26 +11,29 @@ import FormStep from './FormStep';
 export default class ScheduleStep extends FormStep {
   constructor(props) {
     super(props);
+    this.state.fields = {
+      startTime: props.fields.startTime || '',
+      endTime: props.fields.endTime || '',
+    };
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
     this.changeStartTime = this.changeStartTime.bind(this);
     this.changeEndTime = this.changeEndTime.bind(this);
   }
 
   handleSubmit(event) {
     event.preventDefault();
-
-    if (!this.state.startTime || !this.state.endTime) {
+    if (!this.state.fields.startTime || !this.state.fields.endTime) {
       this.setState({error: 'Tous les champs sont requis.'});
       return;
     }
 
-    this.valiDate(this.state.startTime, this.state.endTime);
-
-    this.setFields({startTime: this.state.startTime, endTime: this.state.endTime});
+    this.validateDate(this.state.fields.startTime, this.state.fields.endTime);
+    this.setFields({startTime: this.state.fields.startTime, endTime: this.state.fields.endTime});
     this.jumpToStep(this.props.step + 1);
   }
 
-  valiDate(startTime, endTime) {
+  validateDate(startTime, endTime) {
     if (typeof startTime === 'string' || typeof endTime === 'string') {
       this.setState({error: 'Merci de saisir des dates valides.'});
       return;
@@ -40,13 +43,22 @@ export default class ScheduleStep extends FormStep {
   }
 
   changeStartTime(value) {
-    this.setState({startTime: value, endTime: null});
-    this.valiDate(value, null);
+    this.setState({
+      fields: Object.assign(this.state.fields, {
+        startTime: value,
+        endTime: null,
+      }),
+    });
+    this.validateDate(value, null);
   }
 
   changeEndTime(value) {
-    this.setState({endTime: value});
-    this.valiDate(this.state.startTime, value);
+    this.setState({
+      fields: Object.assign(this.state.fields, {
+        endTime: value,
+      }),
+    });
+    this.validateDate(this.state.fields.startTime, value);
   }
 
   render() {
@@ -67,11 +79,21 @@ export default class ScheduleStep extends FormStep {
           <form onSubmit={this.handleSubmit}>
             <div className="form-group">
               <label className="control-label">Début de l'événement</label>
-              <Datetime locale="fr" onChange={this.changeStartTime} isValidDate={d => d.isAfter(Datetime.moment().subtract(1, 'day'))}/>
+              <Datetime
+                locale="fr"
+                onChange={this.changeStartTime}
+                isValidDate={d => d.isAfter(Datetime.moment().subtract(1, 'day'))}
+                value={this.state.fields.startTime}
+              />
             </div>
             <div className="form-group">
               <label className="control-label">Fin de l'événement</label>
-              <Datetime locale="fr" value={this.state.endTime} onChange={this.changeEndTime} isValidDate={d => d.isAfter((Datetime.moment(this.state.startTime) || Datetime.moment()).clone().subtract(1, 'day'))}/>
+              <Datetime
+                locale="fr"
+                onChange={this.changeEndTime}
+                isValidDate={d => d.isAfter((Datetime.moment(this.state.startTime) || Datetime.moment()).clone().subtract(1, 'day'))}
+                value={this.state.fields.endTime}
+              />
             </div>
             {this.state.error && (
               <div className="alert alert-warning">


### PR DESCRIPTION
Hello @aktiur / @guilro :

J'ai rencontré deux problèmes récemment en utilisant le site :
 * Lorsque je veux créer des événements (idem pour un GA), c'est pénible car je peux pas revenir dans le FormStep pour modifier une ancienne valeur.
 * La propriété `contact_name` n'est plus éditable, ce qui fait que l'on ne peut plus la modifier sur les GA créés avec l'ancien formulaire. On a par exemple sur des GA des `Ancien Nom <nouvelle.adresse@mail.com>` qui ne sont plus modifiables.

J'ai donc fait une PR avec ces éléments :
 * J'ai rétabli le `contact_name` (en facultatif) dans la création d'un GA
 * J'ai ajouté `contact_name` également dans l'édition d'un GA
 * J'ai rendu `contact_email` obligatoire dans la création d'un GA et d'un événement
 * J'ai changé les "step forms" pour qu'ils soient des composants contrôlés ; ainsi quand on appuie sur "retour", le formulaire est peuplé avec la valeur renseignée précédemment
 * Et qq trucs techniques :
   * `Object.assign` n'existe pas sur IE => j'ai utilisé le wrapper de lodash
   * J'ai ajouté explicitement l'option `nfs` dans le Vagrantfile (par défaut à false pour pas péter les install existantes)
   * J'ai activé le support de fonctionnalités ES6, comme spread function

Voilà :)