### PR TITLE
maj de rendu sur la page des groupes

### DIFF
--- a/agir/groups/templates/groups/detail.html
+++ b/agir/groups/templates/groups/detail.html
@@ -87,47 +87,70 @@
         {% endif %}
     </div>
 
-    <h3>Agenda du groupe
-      {% url 'ics_group' supportgroup.pk as calendar_url %}
-      <small>S'abonner {% include 'events/calendar_subscribe_modal.html' with url=calendar_url %}</small>
-    </h3>
-    <div class="list-group">
-        {% for event in supportgroup.organized_events.upcoming.distinct %}
-            <div class="list-group-item">
-                <strong>
-                    <a href="{% url "view_event" event.pk %}">{{ event.name }}</a>
-                    <small>
-                        &bull; <a href="{% url "manage_event" event.pk %}">Gestion</a>
-                    </small>
-                </strong>
-                <div>{{ event.get_display_date }}</div>
-                <div>{{ event.location_name }}</div>
+    <div class="row masonry">
+        <div class="col-md-6">
+            <h3>Agenda du groupe
+              {% url 'ics_group' supportgroup.pk as calendar_url %}
+              <small>S'abonner {% include 'events/calendar_subscribe_modal.html' with url=calendar_url %}</small>
+            </h3>
+            <div class="list-group">
+                {% for event in supportgroup.organized_events.upcoming.distinct %}
+                    <div class="list-group-item">
+                        <div class="media">
+                            <div class="media-left media-middle"  style="min-width:64px">
+                                {% if event.image %}
+                                    <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
+                                {% endif %}
+                            </div>
+                            <div class="media-body">
+                                <strong>
+                                    <a href="{% url "view_event" event.pk %}">{{ event.name }}</a>
+                                    <small>
+                                        &bull; <a href="{% url "manage_event" event.pk %}">Gestion</a>
+                                    </small>
+                                </strong>
+                                <div>{{ event.get_display_date }}</div>
+                                <div>{{ event.location_name }}</div>
+                            </div>
+                        </div>
+                    </div>
+                {% empty %}
+                    <div class="list-group-item">
+                        Ce groupe n'a aucun événement à venir.
+                    </div>
+                {% endfor %}
             </div>
-        {% empty %}
-            <div class="list-group-item">
-                Ce groupe n'a aucun événement à venir.
+        </div>
+        <div class="col-md-6">
+            <h3>Événements passés</h3>
+            <div class="list-group">
+                {% for event in supportgroup.organized_events.past.distinct %}
+                    <div class="list-group-item">
+                        <div class="media">
+                            <div class="media-left media-middle"  style="min-width:64px">
+                                {% if event.image %}
+                                    <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
+                                {% endif %}
+                            </div>
+                            <div class="media-body">
+                                <strong>
+                                    <a href="{% url "view_event" event.pk %}">{{ event.name }}</a>
+                                    <small>
+                                        &bull; <a href="{% url "manage_event" event.pk %}">Gestion</a>
+                                    </small>
+                                </strong>
+                                <div>{{ event.get_display_date }}</div>
+                                <div>{{ event.location_name }}</div>
+                            </div>
+                        </div>
+                    </div>
+                {% empty %}
+                    <div class="list-group-item">
+                        Ce groupe n'a organisé aucun événement.
+                    </div>
+                {% endfor %}
             </div>
-        {% endfor %}
-    </div>
-
-    <h3>Événements passés</h3>
-    <div class="list-group">
-        {% for event in supportgroup.organized_events.past.distinct %}
-            <div class="list-group-item">
-                <strong>
-                    <a href="{% url "view_event" event.pk %}">{{ event.name }}</a>
-                    <small>
-                        &bull; <a href="{% url "manage_event" event.pk %}">Gestion</a>
-                    </small>
-                </strong>
-                <div>{{ event.get_display_date }}</div>
-                <div>{{ event.location_name }}</div>
-            </div>
-        {% empty %}
-            <div class="list-group-item">
-                Ce groupe n'a organisé aucun événement.
-            </div>
-        {% endfor %}
+        </div>
     </div>
 
 {% endblock %}


### PR DESCRIPTION
-  images sur les événements dans les agendas des groupes
- `Agenda du groupe` et `Événements passés` sont cote à cote