### PR TITLE
affichage des événements regroupé par jour

### DIFF
--- a/agir/events/views/utils.py
+++ b/agir/events/views/utils.py
@@ -1,0 +1,12 @@
+from itertools import groupby
+from collections import namedtuple
+
+
+EventByDay = namedtuple("EventByDay", ["date", "events"])
+
+
+def group_events_by_day(events):
+    events_grouped = []
+    for key, group in groupby(events, key=lambda event: event.start_time.date()):
+        events_grouped.append(EventByDay(key, list(group)))
+    return events_grouped

--- a/agir/groups/templates/groups/detail.html
+++ b/agir/groups/templates/groups/detail.html
@@ -94,26 +94,30 @@
               <small>S'abonner {% include 'events/calendar_subscribe_modal.html' with url=calendar_url %}</small>
             </h3>
             <div class="list-group">
-                {% for event in supportgroup.organized_events.upcoming.distinct %}
-                    <div class="list-group-item">
-                        <div class="media">
-                            <div class="media-left media-middle"  style="min-width:64px">
-                                {% if event.image %}
-                                    <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
-                                {% endif %}
-                            </div>
-                            <div class="media-body">
-                                <strong>
-                                    <a href="{% url "view_event" event.pk %}">{{ event.name }}</a>
-                                    <small>
-                                        &bull; <a href="{% url "manage_event" event.pk %}">Gestion</a>
-                                    </small>
-                                </strong>
-                                <div>{{ event.get_display_date }}</div>
-                                <div>{{ event.location_name }}</div>
+                {% for day, events in events_future %}
+                    <div class="list-group-item disabled">
+                        {{ day|date:"l d F" }}
+                    </div>
+                    {% for event in events %}
+                        <div class="list-group-item">
+                            <div class="media">
+                                <div class="media-left media-middle"  style="min-width:64px">
+                                    {% if event.image %}
+                                        <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
+                                    {% endif %}
+                                </div>
+                                <div class="media-body">
+                                    <strong>
+                                        <a href="{% url "view_event" event.pk %}">{{ event.name }}</a>
+                                        <small>
+                                            &bull; <a href="{% url "manage_event" event.pk %}">Gestion</a>
+                                        </small>
+                                    </strong>
+                                    <div>{{ event.start_time|date:"H:i" }} {% if event.location_name %}- {{ event.location_name }} {% endif %}</div>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    {% endfor %}
                 {% empty %}
                     <div class="list-group-item">
                         Ce groupe n'a aucun événement à venir.
@@ -124,26 +128,30 @@
         <div class="col-md-6">
             <h3>Événements passés</h3>
             <div class="list-group">
-                {% for event in supportgroup.organized_events.past.distinct %}
-                    <div class="list-group-item">
-                        <div class="media">
-                            <div class="media-left media-middle"  style="min-width:64px">
-                                {% if event.image %}
-                                    <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
-                                {% endif %}
-                            </div>
-                            <div class="media-body">
-                                <strong>
-                                    <a href="{% url "view_event" event.pk %}">{{ event.name }}</a>
-                                    <small>
-                                        &bull; <a href="{% url "manage_event" event.pk %}">Gestion</a>
-                                    </small>
-                                </strong>
-                                <div>{{ event.get_display_date }}</div>
-                                <div>{{ event.location_name }}</div>
+                {% for day, events in events_past %}
+                    <div class="list-group-item disabled">
+                        {{ day|date:"l d F" }}
+                    </div>
+                    {% for event in events %}
+                        <div class="list-group-item">
+                            <div class="media">
+                                <div class="media-left media-middle"  style="min-width:64px">
+                                    {% if event.image %}
+                                        <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
+                                    {% endif %}
+                                </div>
+                                <div class="media-body">
+                                    <strong>
+                                        <a href="{% url "view_event" event.pk %}">{{ event.name }}</a>
+                                        <small>
+                                            &bull; <a href="{% url "manage_event" event.pk %}">Gestion</a>
+                                        </small>
+                                    </strong>
+                                    <div>{{ event.start_time|date:"H:i" }} {% if event.location_name %}- {{ event.location_name }} {% endif %}</div>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    {% endfor %}
                 {% empty %}
                     <div class="list-group-item">
                         Ce groupe n'a organisé aucun événement.

--- a/agir/lib/tests/mixins.py
+++ b/agir/lib/tests/mixins.py
@@ -1,11 +1,9 @@
 from datetime import timedelta
 
-from django.contrib.auth.models import Group
+from django.contrib.gis.geos import Point
 from django.db import transaction
 from django.utils import timezone
-from django.contrib.gis.geos import Point
 
-from agir.clients.models import Client
 from agir.events.models import Calendar, Event, OrganizerConfig, RSVP
 from agir.groups.models import SupportGroup, Membership, SupportGroupSubtype
 from agir.people.models import Person, PersonForm, PersonFormSubmission

--- a/agir/people/templates/people/dashboard.html
+++ b/agir/people/templates/people/dashboard.html
@@ -4,7 +4,7 @@
 {% block title %}Mon tableau de bord{% endblock title %}
 
 {% block extra_scripts %}
-{% render_bundle 'people/dashboard' attrs='defer' %}
+    {% render_bundle 'people/dashboard' attrs='defer' %}
 {% endblock %}
 
 {% block main %}
@@ -27,22 +27,28 @@
                 </a>
             </h3>
             <div class="list-group">
-                {% for event in rsvped_events %}
-                    <div class="list-group-item">
-                        <div class="media">
-                            <div class="media-left media-middle"  style="min-width:64px">
-                                {% if event.image %}
-                                    <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
-                                {% endif %}
-                            </div>
-                            <div class="media-body">
-                                <i class="fa fa-calendar" aria-hidden="true"></i>
-                                <a href="{% url 'view_event' event.pk %}">{{ event.name }}</a><br>
-                                {{ event.get_display_date }} - {{ event.short_location }}
-                                {% if event.distance %} - {{ event.distance.km|floatformat }} km{% endif %}
+                {% for day, events in rsvped_events %}
+                    <div class="list-group-item disabled">
+                        {{ day|date:"l d F" }}
+                    </div>
+                    {% for event in events %}
+                        <div class="list-group-item">
+                            <div class="media">
+                                <div class="media-left media-middle" style="min-width:64px">
+                                    {% if event.image %}
+                                        <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
+                                    {% endif %}
+                                </div>
+                                <div class="media-body">
+                                    <i class="fa fa-calendar" aria-hidden="true"></i>
+                                    <a href="{% url 'view_event' event.pk %}">{{ event.name }}</a>
+                                    <br>
+                                    {{ event.start_time|date:"H:i" }} - {{ event.short_location }}
+                                    {% if event.distance %} - {{ event.distance.km|floatformat }} km{% endif %}
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    {% endfor %}
                 {% empty %}
                     <div class="list-group-item">
                         Vous n'avez aucun événément prévu pour le moment.
@@ -94,24 +100,31 @@
             </div>
             <h3>Événements suggérés</h3>
             <div class="list-group">
-                {% for event in suggested_events %}
-                    <div class="list-group-item">
-                        <div class="media">
-                            <div class="media-left media-middle"  style="min-width:64px">
-                                {% if event.image %}
-                                    <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
-                                {% endif %}
-                            </div>
-                            <div class="media-body">
-                                <span class="small text-muted pull-right" data-toggle="tooltip"
+                {% for day, events in suggested_events %}
+                    <div class="list-group-item disabled">
+                        {{ day|date:"l d F" }}
+                    </div>
+
+                    {% for event in events %}
+                        <div class="list-group-item">
+                            <div class="media">
+                                <div class="media-left media-middle" style="min-width:64px">
+                                    {% if event.image %}
+                                        <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
+                                    {% endif %}
+                                </div>
+                                <div class="media-body">
+                                    <span class="small text-muted pull-right" data-toggle="tooltip"
                                       title="{{ event.reason }}">Pourquoi ?</span>
-                                <i class="fa fa-calendar" aria-hidden="true"></i>
-                                <a href="{% url 'view_event' event.pk %}">{{ event.name }}</a>
-                                {{ event.get_display_date }} - {{ event.short_location }}
-                                {% if event.distance %} - {{ event.distance.km|floatformat }} km{% endif %}
+                                    <i class="fa fa-calendar" aria-hidden="true"></i>
+                                    <a href="{% url 'view_event' event.pk %}">{{ event.name }}</a>
+                                    <br>
+                                    {{ event.start_time|date:"H:i" }} - {{ event.short_location }}
+                                    {% if event.distance %} - {{ event.distance.km|floatformat }} km{% endif %}
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    {% endfor %}
                 {% empty %}
                     <div class="list-group-item">
                         Aucun événement suggéré ! Rejoignez un groupe d'action pour voir des événements.
@@ -130,7 +143,7 @@
                 {% for event in last_events %}
                     <div class="list-group-item">
                         <div class="media">
-                            <div class="media-left media-middle"  style="min-width:64px">
+                            <div class="media-left media-middle" style="min-width:64px">
                                 {% if event.image %}
                                     <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
                                 {% endif %}
@@ -138,7 +151,7 @@
                             <div class="media-body">
                                 <i class="fa fa-calendar" aria-hidden="true"></i>
                                 <a href="{% url 'view_event' event.pk %}">{{ event.name }}</a>
-                                {{ event.get_display_date }} - {{ event.short_location }}
+                                <br> {{ event.get_display_date }} - {{ event.short_location }}
                             </div>
                         </div>
                     </div>
@@ -159,7 +172,7 @@
                 {% for event in past_reports %}
                     <div class="list-group-item">
                         <div class="media">
-                            <div class="media-left media-middle"  style="min-width:64px">
+                            <div class="media-left media-middle" style="min-width:64px">
                                 {% if event.image %}
                                     <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
                                 {% endif %}
@@ -167,7 +180,8 @@
                             <div class="media-body">
                                 <i class="fa fa-calendar" aria-hidden="true"></i>
                                 <a href="{% url 'view_event' event.pk %}">{{ event.name }}</a>
-                                {%  if event.organizers_groups %}(organisé par {{  event.organizers_groups.all|join:', ' }}){% endif %}
+                                {% if event.organizers_groups %}(organisé par
+                                    {{ event.organizers_groups.all|join:', ' }}){% endif %}
                                 <br>
                                 {{ event.get_display_date }} - {{ event.short_location }}
                             </div>
@@ -197,7 +211,7 @@
                 {% for event in organized_events %}
                     <div class="list-group-item">
                         <div class="media">
-                            <div class="media-left media-middle"  style="min-width:64px">
+                            <div class="media-left media-middle" style="min-width:64px">
                                 {% if event.image %}
                                     <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
                                 {% endif %}
@@ -222,7 +236,7 @@
                 {% for event in past_organized_events %}
                     <div class="list-group-item">
                         <div class="media">
-                            <div class="media-left media-middle"  style="min-width:64px">
+                            <div class="media-left media-middle" style="min-width:64px">
                                 {% if event.image %}
                                     <img src="{{ event.image.thumbnail.url }}" class="media-object img-responsive">
                                 {% endif %}
@@ -235,8 +249,8 @@
                     </div>
                 {% empty %}
                     <div class="list-group-item">
-                        Vous n'avez organisé aucun événement terminé. Voulez-vous <a href="{% url 'create_event' %}">en créer
-                        un</a>&nbsp;?
+                        Vous n'avez organisé aucun événement terminé. Voulez-vous <a href="{% url 'create_event' %}">en
+                        créer un</a>&nbsp;?
                     </div>
                 {% endfor %}
             </div>

--- a/agir/people/views/dashboard.py
+++ b/agir/people/views/dashboard.py
@@ -8,6 +8,7 @@ from django.views.generic import TemplateView
 from agir.authentication.view_mixins import SoftLoginRequiredMixin
 from agir.events.models import Event
 from agir.groups.models import SupportGroup
+from agir.events.views.utils import group_events_by_day
 from agir.lib.tasks import geocode_person
 
 
@@ -54,6 +55,7 @@ class DashboardView(SoftLoginRequiredMixin, TemplateView):
                     TextField(),
                 )
             )
+            .order_by("start_time")
         )
         if person.coordinates is not None:
             suggested_events = suggested_events.annotate(
@@ -112,14 +114,13 @@ class DashboardView(SoftLoginRequiredMixin, TemplateView):
         kwargs.update(
             {
                 "person": person,
-                "rsvped_events": rsvped_events,
+                "rsvped_events": group_events_by_day(rsvped_events),
                 "members_groups": members_groups,
-                "suggested_events": suggested_events,
+                "suggested_events": group_events_by_day(suggested_events),
                 "last_events": last_events,
                 "past_reports": past_reports,
                 "organized_events": organized_events,
                 "past_organized_events": past_organized_events,
             }
         )
-
         return super().get_context_data(**kwargs)


### PR DESCRIPTION
L'édiée est juste de regrouper par jour des événement qui sont déjà
triée chronologiquement. Concretement un élément de liste en rajouter
en précisant la date ex: "Vendredi 12 avril". La classe `disabled` pour
etre d'une couleur differente et "douce".

dans la page de groupe:
    - Agenda du groupe (ordre chronologiaue)
    - ordre anti-chronologique

dans le dashboard:
    - Mon agendat
    - Événements suggérés